### PR TITLE
use DejaVuSans.ttf font when drawing box

### DIFF
--- a/deepseek_vl/serve/app_modules/utils.py
+++ b/deepseek_vl/serve/app_modules/utils.py
@@ -301,7 +301,7 @@ def parse_ref_bbox(response, image):
             text_x = box[0]
             text_y = box[1] - 20
             text_color = box_color
-            font = ImageFont.truetype('./deepseek_vl/serve/assets/simsun.ttc', size=20)
+            font = ImageFont.truetype('DejaVuSans.ttf', size=20)
             draw.text((text_x, text_y), label, font=font, fill=text_color)
 
         return image


### PR DESCRIPTION
1. 在nvidia pytorch docker环境下使用的时候，会出现OS Error
![WX20241214-215748@2x](https://github.com/user-attachments/assets/a84805c8-4781-4ed9-9cdc-e7b896d37846)

2.修改了字体文件引用的路径之后依然会有该问题出现，在docker中无法直接使用ttc字体文件，改为使用系统自带的ttf字体文件即可解决该问题

3. 同时移除ttc字体文件，减少仓库体积
 
