### PR TITLE
Remove incorrect  chunk_size parameter from retry function

### DIFF
--- a/web_demo.py
+++ b/web_demo.py
@@ -448,8 +448,7 @@ def retry(
         repetition_penalty,
         max_length_tokens,
         max_context_length_tokens,
-        model_select_dropdown,
-        args.chunk_size
+        model_select_dropdown
     )
 
 


### PR DESCRIPTION
Before removal, the invocation will throw an error: parameter count mismatch.